### PR TITLE
Modmail URL is not excluded from redirects

### DIFF
--- a/oldRedditRedirect.user.js
+++ b/oldRedditRedirect.user.js
@@ -8,6 +8,7 @@
 // @exclude *out.reddit.com/*
 // @exclude *://*.reddit.com/gallery/*
 // @exclude *://*.reddit.com/media*
+// @exclude *://mod.reddit.com/*
 // @run-at document-start
 // @grant        none
 // ==/UserScript==

--- a/oldRedditRedirect.user.js
+++ b/oldRedditRedirect.user.js
@@ -9,6 +9,7 @@
 // @exclude *://*.reddit.com/gallery/*
 // @exclude *://*.reddit.com/media*
 // @exclude *://*.reddit.com/message/*
+// @exclude *://chat.reddit.com/*
 // @exclude *://mod.reddit.com/*
 // @run-at document-start
 // @grant        none

--- a/oldRedditRedirect.user.js
+++ b/oldRedditRedirect.user.js
@@ -8,6 +8,7 @@
 // @exclude *out.reddit.com/*
 // @exclude *://*.reddit.com/gallery/*
 // @exclude *://*.reddit.com/media*
+// @exclude *://*.reddit.com/message/*
 // @exclude *://mod.reddit.com/*
 // @run-at document-start
 // @grant        none


### PR DESCRIPTION
Modmail/Moderation Mail, which is used by Reddit moderators to review messages and alerts directed to them, is only available through the following URL: https://mod.reddit.com; since this subdomain is not excluded by the rule-set in this script, it causes a redirect loop when going to this URL. I have added an exclusion for this URL.